### PR TITLE
Publication links

### DIFF
--- a/_faq/how-do-I-cite-IGSR.md
+++ b/_faq/how-do-I-cite-IGSR.md
@@ -11,7 +11,7 @@ redirect_from:
     - /faq/how-do-i-cite-1000-genomes-project/
 ---
 
-When citing IGSR in general, please cite our [Nucleic Acids Research database paper](https://academic.oup.com/nar/article/45/D1/D854/2770649). For further details on citing specifc data sets, please see the appropriate data reuse policy and also cite any appropriate publication. Publications that we are aware of are listed alongside the data collections in our [data portal](/data-portal/data-collection).
+When citing IGSR in general, please cite our [Nucleic Acids Research database paper](https://academic.oup.com/nar/article/48/D1/D941/5580898?login=true). For further details on citing specifc data sets, please see the appropriate data reuse policy and also cite any appropriate publication. Publications that we are aware of are listed alongside the data collections in our [data portal](/data-portal/data-collection).
 
 When citing the 1000 Genomes Project in general please use the final phase 3 paper, [A global reference for human genetic variation, The 1000 Genomes Project Consortium, Nature 526, 68-74 (01 October 2015) doi:10.1038/nature15393](http://www.nature.com/nature/journal/v526/n7571/full/nature15393.html). This paper is published under the creative commons Attribution-NonCommercial-ShareAlike 3.0 Unported licence, please feel free to share and redistribute the paper appropriately.
 

--- a/data.md
+++ b/data.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Using data from IGSR
 
-IGSR provides open data to support the community's research efforts. You can see our terms of use in our [data disclaimer](/IGSR_disclaimer). Please also consult the associated data reuse statements and cite associated publications appropriately. To cite IGSR, please use our [NAR paper](https://academic.oup.com/nar/article/45/D1/D854/2770649).
+IGSR provides open data to support the community's research efforts. You can see our terms of use in our [data disclaimer](/IGSR_disclaimer). Please also consult the associated data reuse statements and cite associated publications appropriately. To cite IGSR, please use our [NAR paper](https://academic.oup.com/nar/article/48/D1/D941/5580898?login=true).
 
 #Explore the data sets in IGSR through our [data portal](/data-portal)  
 


### PR DESCRIPTION
IGSR has had two NAR publications. We noticed a link still pointing to the old publication (Clarke et al) and, on searching, found another. This updates those two links to point to the newer NAR publication (Fairley et al).