### PR TITLE
Make data collection list files have labelled filenames upon download

### DIFF
--- a/_data-portal/app/core/services/api-population.service.ts
+++ b/_data-portal/app/core/services/api-population.service.ts
@@ -114,7 +114,7 @@ export class ApiPopulationService {
         }
       }
     }
-    return this.searchExport(query, `igsr-${filename}-populations.tsv`);
+    return this.searchExport(query, `igsr-${filename}-populations`);
   }
 
   // private methods

--- a/_data-portal/app/core/services/api-population.service.ts
+++ b/_data-portal/app/core/services/api-population.service.ts
@@ -114,7 +114,7 @@ export class ApiPopulationService {
         }
       }
     }
-    return this.searchExport(query, `igsr-${filename}.tsv`);
+    return this.searchExport(query, `igsr-${filename}-populations.tsv`);
   }
 
   // private methods

--- a/_data-portal/app/core/services/api-sample.service.ts
+++ b/_data-portal/app/core/services/api-sample.service.ts
@@ -99,7 +99,7 @@ export class ApiSampleService {
         }
       }
     }
-    return this.searchExport(query, `igsr-${filename}-samples.tsv`);
+    return this.searchExport(query, `igsr-${filename}-samples`);
   }
 
   searchPopulationSamples(popCode: string, offset: number, hitsPerPage: number): Observable<SearchHits<Sample>> {

--- a/_data-portal/app/core/services/api-sample.service.ts
+++ b/_data-portal/app/core/services/api-sample.service.ts
@@ -99,7 +99,7 @@ export class ApiSampleService {
         }
       }
     }
-    return this.searchExport(query, `igsr-${filename}.tsv`);
+    return this.searchExport(query, `igsr-${filename}-samples.tsv`);
   }
 
   searchPopulationSamples(popCode: string, offset: number, hitsPerPage: number): Observable<SearchHits<Sample>> {


### PR DESCRIPTION
## Description

This PR updates the data-portal/data-collection "Download the list" functionality on the IGSR data portal. The changes ensure that the buttons for samples and populations generate files with correctly labelled filenames:
- Sample lists now download as `igsr-*-samples.tsv`
- Population lists now download as `igsr-*-populations.tsv`

`.tsv` was removed (as the files were downloading as `.tsv.tsv`)  and `-samples`/`-populations` was added to the download file name. 

The modifications are made in the files:
- `api-sample.service.ts` (for samples)
- `api-population.service.ts` (for populations)

## Use case
Prior to this change, both the sample and population download links generated files with the same name, leading to potential file overwrites and confusion for users. This update addresses that issue.

## Benefits
- Users can now clearly distinguish between the downloaded files for samples and populations.

## Possible Drawbacks
- The change uses hardcoded filenames, however, for the current requirements, this approach is sufficient.

## Testing

- The changes were manually tested on the staging environment. The “Download the list” buttons now trigger downloads with the correct filenames. An example for the 1000 genomes grch38 is: 
    - `igsr-1000 genomes on grch38-samples.tsv` for samples
    - `igsr-1000 genomes on grch38-populations.tsv` for populations